### PR TITLE
Monit Role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -64,7 +64,6 @@
         - monit
 
   roles:
-    - { role: monit }
     - { role: bitcoin, when:  currency_type == 'bitcoin' }
     - { role: litecoin, when:  currency_type == 'litecoin' }
     - { role: ethereum, when:  currency_type == 'ethereum' }

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,6 +3,7 @@
 
   vars_files:
     - vars/general.yml
+    - roles/monit/defaults/main.yml
 
   pre_tasks:
     - name: Create Dev Dir

--- a/playbook.yml
+++ b/playbook.yml
@@ -64,6 +64,7 @@
         - monit
 
   roles:
+    - { role: monit }
     - { role: bitcoin, when:  currency_type == 'bitcoin' }
     - { role: litecoin, when:  currency_type == 'litecoin' }
     - { role: ethereum, when:  currency_type == 'ethereum' }

--- a/roles/bitcoin/meta/main.yml
+++ b/roles/bitcoin/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: monit }

--- a/roles/bitcoin/tasks/main.yml
+++ b/roles/bitcoin/tasks/main.yml
@@ -47,9 +47,9 @@
   become: true
   blockinfile:
     dest: "{{ monit_control_path }}"
-    create: yes
     owner: root
     group: root
     mode: 0600
+    insertafter: EOF
     block: |
       {{ monitrc_file_content }}

--- a/roles/bitcoin/vars/main.yml
+++ b/roles/bitcoin/vars/main.yml
@@ -1,9 +1,6 @@
 bitcoin_version: v0.15.1
 
 monitrc_file_content: |
-  set daemon 60
-  set logfile /var/log/monit.log
-
   check process {{ currency_type }}d with pidfile "{{ blockchainpath }}/{{ currency_type }}.pid"
       start program "/usr/local/bin/{{ currency_type }}d -datadir={{ blockchainpath }} -daemon"
       stop program "/usr/local/bin/{{ currency_type }}-cli -datadir={{ blockchainpath }} stop"

--- a/roles/ethereum/meta/main.yml
+++ b/roles/ethereum/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: monit }

--- a/roles/ethereum/tasks/main.yml
+++ b/roles/ethereum/tasks/main.yml
@@ -35,5 +35,6 @@
     owner: root
     group: root
     mode: 0600
+    insertafter: EOF
     block: |
       {{ monitrc_file_content }}

--- a/roles/ethereum/tasks/main.yml
+++ b/roles/ethereum/tasks/main.yml
@@ -31,7 +31,6 @@
   become: true
   blockinfile:
     dest: "{{ monit_control_path }}"
-    create: yes
     owner: root
     group: root
     mode: 0600

--- a/roles/ethereum/vars/main.yml
+++ b/roles/ethereum/vars/main.yml
@@ -1,9 +1,6 @@
 ethereum_version: v1.7.3
 
 monitrc_file_content: |
-  set daemon 60
-  set logfile /var/log/monit.log
-
   check process geth matching "geth"
       start program "/usr/bin/tmux/tmux new -d -s sync_blockchain 'geth --datadir {{ blockchainpath }} --ipcdisable --syncmode 'fast' --cache=512'"
       stop program "tmux kill-session -t sync_blockchain"

--- a/roles/litecoin/meta/main.yml
+++ b/roles/litecoin/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: monit }

--- a/roles/litecoin/tasks/main.yml
+++ b/roles/litecoin/tasks/main.yml
@@ -47,7 +47,6 @@
   become: true
   blockinfile:
     dest: "{{ monit_control_path }}"
-    create: yes
     owner: root
     group: root
     mode: 0600

--- a/roles/litecoin/tasks/main.yml
+++ b/roles/litecoin/tasks/main.yml
@@ -51,5 +51,6 @@
     owner: root
     group: root
     mode: 0600
+    insertafter: EOF
     block: |
       {{ monitrc_file_content }}

--- a/roles/litecoin/vars/main.yml
+++ b/roles/litecoin/vars/main.yml
@@ -1,9 +1,6 @@
 litecoin_version: v0.13.3
 
 monitrc_file_content: |
-  set daemon 60
-  set logfile /var/log/monit.log
-
   check process {{ currency_type }}d with pidfile "{{ blockchainpath }}/{{ currency_type }}.pid"
       start program "/usr/local/bin/{{ currency_type }}d -datadir={{ blockchainpath }} -daemon"
       stop program "/usr/local/bin/{{ currency_type }}-cli -datadir={{ blockchainpath }} stop"

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -1,0 +1,1 @@
+alert_email: none@none.com

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -1,4 +1,8 @@
+monit_path: "/usr/bin/monit"
+monit_control_path: "/etc/monit/monitrc"
+
 alert_email: none@none.com
+
 server: smtp.gmail.com
 port: 465
 server_username: none@none.com

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -1,1 +1,5 @@
 alert_email: none@none.com
+server: smtp.gmail.com
+port: 465
+server_username: none@none.com
+server_password: password123

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -3,6 +3,7 @@ monit_control_path: "/etc/monit/monitrc"
 
 alert_email: none@none.com
 
+setup_smtp: false
 server: smtp.gmail.com
 port: 465
 server_username: none@none.com

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -22,6 +22,7 @@
     - name: "prompt_password"
       prompt: "Enter SMTP Server Password:"
       private: yes 
+  when: setup_smtp
 
 - name: Setup monitrc SMTP
   tags: setup_monit_smtp

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -9,3 +9,26 @@
     mode: 0600
     block: |
       {{ monitrc_file_content }}
+
+- name: Prompt for SMTP input
+  tags: setup_monit_smtp
+  vars_prompt:
+    - name: "prompt_server"
+      prompt: "Enter SMTP Server:"
+    - name: "prompt_port"
+      prompt: "Enter SMTP Port:"
+    - name: "prompt_username"
+      prompt: "Enter SMTP Server Username:"
+    - name: "prompt_password"
+      prompt: "Enter SMTP Server Password:"
+      private: yes 
+
+- name: Setup monitrc SMTP
+  tags: setup_monit_smtp
+  become: true
+  insertafter: EOF
+  blockinfile:
+    dest: "{{ monit_control_path }}"
+    block: |
+      {{ monit_mail_server }}
+  when: setup_smtp

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: Setup monitrc SMTP
   tags: setup_monit_smtp
   become: true
-  insertafter: EOF
   blockinfile:
     dest: "{{ monit_control_path }}"
+    insertafter: EOF
     block: |
       {{ monit_mail_server }}
   when: setup_smtp

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Setup monitrc file base
+  tags: setup_monitrc_base
+  become: true
+  blockinfile:
+    dest: "{{ monit_control_path }}"
+    create: yes
+    owner: root
+    group: root
+    mode: 0600
+    block: |
+      {{ monitrc_file_content }}

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -10,20 +10,6 @@
     block: |
       {{ monitrc_file_content }}
 
-- name: Prompt for SMTP input
-  tags: setup_monit_smtp
-  vars_prompt:
-    - name: "prompt_server"
-      prompt: "Enter SMTP Server:"
-    - name: "prompt_port"
-      prompt: "Enter SMTP Port:"
-    - name: "prompt_username"
-      prompt: "Enter SMTP Server Username:"
-    - name: "prompt_password"
-      prompt: "Enter SMTP Server Password:"
-      private: yes 
-  when: setup_smtp
-
 - name: Setup monitrc SMTP
   tags: setup_monit_smtp
   become: true

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,5 +1,3 @@
-alert_email: none@none.com
-
 monitrc_file_content: |
   set daemon 60
   set logfile /var/log/monit.log

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,0 +1,3 @@
+monitrc_file_content: |
+  set daemon 60
+  set logfile /var/log/monit.log

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,4 +1,4 @@
-alert_email: <TODO>
+alert_email: none@none.com
 
 monitrc_file_content: |
   set daemon 60

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,3 +1,13 @@
+alert_email: <TODO>
+
 monitrc_file_content: |
   set daemon 60
   set logfile /var/log/monit.log
+  set alert {{ alert_email }} only on { nonexist }
+
+  set mail-format {
+    subject: $SERVICE $DESCRIPTION on $HOST
+    message: $DATE
+             $SERVICE $DESCRIPTION on $HOST
+             $SERVICE $ACTION             
+  }

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -15,6 +15,6 @@ monitrc_file_content: |
 monit_mail_server: |
   set mailserver
       {{ prompt_server }}
-      port {{ prompt_port}}
+      port {{ prompt_port }}
       username {{ prompt_username }} password {{ prompt_password }}
       using ssl

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -6,8 +6,10 @@ monitrc_file_content: |
   set alert {{ alert_email }} only on { nonexist }
 
   set mail-format {
-    subject: $SERVICE $DESCRIPTION on $HOST
-    message: $DATE
-             $SERVICE $DESCRIPTION on $HOST
-             $SERVICE $ACTION             
+      subject: $SERVICE $DESCRIPTION
+      message: $DATE
+  Host:  $HOST
+  Process:  $SERVICE
+  Description:  $DESCRIPTION
+  Action:  Attempting to $ACTION process $SERVICE
   }

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -11,3 +11,10 @@ monitrc_file_content: |
   Description:  $DESCRIPTION
   Action:  Attempting to $ACTION process $SERVICE
   }
+
+monit_mail_server: |
+  set mailserver
+      {{ prompt_server }}
+      port {{ prompt_port}}
+      username {{ prompt_username }} password {{ prompt_password }}
+      using ssl

--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -14,7 +14,7 @@ monitrc_file_content: |
 
 monit_mail_server: |
   set mailserver
-      {{ prompt_server }}
-      port {{ prompt_port }}
-      username {{ prompt_username }} password {{ prompt_password }}
+      {{ server }}
+      port {{ port }}
+      username {{ server_username }} password {{ server_password }}
       using ssl

--- a/vars/general.yml
+++ b/vars/general.yml
@@ -7,3 +7,4 @@ apt_get_valid_time: 86400 #1 day
 monit_path: "/usr/bin/monit"
 monit_control_path: "/etc/monit/monitrc"
 
+alert_email: none@none.com

--- a/vars/general.yml
+++ b/vars/general.yml
@@ -3,8 +3,3 @@ userpath: "/home/{{ username }}"
 blockchainpath: "{{ userpath }}/blockchainData"
 
 apt_get_valid_time: 86400 #1 day
-
-monit_path: "/usr/bin/monit"
-monit_control_path: "/etc/monit/monitrc"
-
-alert_email: none@none.com


### PR DESCRIPTION
What was done:
- move monit to it's own role and include basic functionality
- the roles for ethereum, bitcoin, and litecoin will have their own portions to add to the monit file when it reaches those roles
- set up the email format
- set up smtp options and prompts

Testing:
- [x] send emails successfully when process is down
- [x] ensure --check runs without errors
- [x] ensure email format comes back as expected - tested with ping
- [x] ansible-playbook -v -i "localhost," --connection local playbook.yml --check --extra-vars "currency_type=ethereum setup_smtp=true"
- [x]  ansible-playbook -v -i "localhost," --connection local playbook.yml --check --extra-vars "currency_type=litecoin setup_smtp=true"
- [x]  ansible-playbook -v -i "localhost," --connection local playbook.yml --check --extra-vars "currency_type=bitcoin setup_smtp=true"