### PR TITLE
Setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import subprocess
 
+subprocess.call("apt-get update", shell=True)
+subprocess.call("apt-get upgrade -y", shell=True)
 subprocess.call("apt-get install vim -y", shell=True)
 subprocess.call("apt-get install tmux -y", shell=True)
 subprocess.call("apt-get install ansible -y", shell=True)

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,18 @@ import subprocess
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--skip_ansible_install",
+parser.add_argument("--skip-ansible-install",
                         action = "store_false",
                         help = "allows skipping of ansible install")
-parser.add_argument("-c", "--currency_type",
+parser.add_argument("-c", "--currency-type",
                         required = True,
                         help="bitcoin, ethereum, litecoin")
 parser.add_argument("--smtp",
                         action = "store_true",
                         help = "if you have the smpt server, port, username, and password you can set up alerting")
+parser.add_argument("-d", "--dry-run",
+                       action = "store_true",
+                       help = "dry-run ansible playbook")
 args = parser.parse_args()
 
 #Install ansible. Allows the running of the ansible script
@@ -20,7 +23,10 @@ if (args.skip_ansible_install):
   subprocess.call("apt-get install ansible -y", shell=True)
 
 #Run the ansible commands to set up the node
+dry_run = ""
+if (args.dry_run):
+  dry_run = "--check"
 
-print args.currency_type
-if (args.smtp is not None):
-  print args.smtp
+command = 'ansible-playbook -v -i "localhost," --connection local playbook.yml %s --extra-vars "currency_type=%s setup_smtp=%s"' % (dry_run, args.currency_type, str(args.smtp))
+print command
+subprocess.call(command, shell=True)

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--skip_ansible_install",
-                        action="store_false",
-                        help="allows skipping of ansible install")
+                        action = "store_false",
+                        help = "allows skipping of ansible install")
 parser.add_argument("-c", "--currency_type",
-                        required=True,
+                        required = True,
                         help="bitcoin, ethereum, litecoin")
 parser.add_argument("--smtp",
-                        help="if you have the smpt server, port, username, and password you can set up alerting")
+                        action = "store_true",
+                        help = "if you have the smpt server, port, username, and password you can set up alerting")
 args = parser.parse_args()
 
 #Install ansible. Allows the running of the ansible script
@@ -19,5 +20,7 @@ if (args.skip_ansible_install):
   subprocess.call("apt-get install ansible -y", shell=True)
 
 #Run the ansible commands to set up the node
+
 print args.currency_type
-print args.setup_smtp
+if (args.smtp is not None):
+  print args.smtp

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,23 @@
 import subprocess
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--skip_ansible_install",
+                        action="store_false",
+                        help="allows skipping of ansible install")
+parser.add_argument("-c", "--currency_type",
+                        required=True,
+                        help="bitcoin, ethereum, litecoin")
+parser.add_argument("--smtp",
+                        help="if you have the smpt server, port, username, and password you can set up alerting")
+args = parser.parse_args()
 
 #Install ansible. Allows the running of the ansible script
-subprocess.call("apt-get update", shell=True)
-subprocess.call("apt-get upgrade -y", shell=True)
-subprocess.call("apt-get install ansible -y", shell=True)
+if (args.skip_ansible_install):
+  subprocess.call("apt-get update", shell=True)
+  subprocess.call("apt-get upgrade -y", shell=True)
+  subprocess.call("apt-get install ansible -y", shell=True)
 
 #Run the ansible commands to set up the node
+print args.currency_type
+print args.setup_smtp

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ if (args.skip_ansible_install):
   subprocess.call("apt-get install ansible -y", shell=True)
 
 #Run the ansible commands to set up the node
-dry_run = ""
-if (args.dry_run):
-  dry_run = "--check"
+dry_run = "--check" if (args.dry_run) else ""
 
 command = 'ansible-playbook -v -i "localhost," --connection local playbook.yml %s --extra-vars "currency_type=%s setup_smtp=%s"' % (dry_run, args.currency_type, str(args.smtp))
 print command

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+import subprocess
+
+subprocess.call("apt-get install vim -y", shell=True)
+subprocess.call("apt-get install tmux -y", shell=True)
+subprocess.call("apt-get install ansible -y", shell=True)
+

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import subprocess
 
+#Install ansible. Allows the running of the ansible script
 subprocess.call("apt-get update", shell=True)
 subprocess.call("apt-get upgrade -y", shell=True)
-subprocess.call("apt-get install vim -y", shell=True)
-subprocess.call("apt-get install tmux -y", shell=True)
 subprocess.call("apt-get install ansible -y", shell=True)
 
+#Run the ansible commands to set up the node


### PR DESCRIPTION
this makes it so that after checking out code, one can just run 

`sudo python setup.py`
with the following arguments
```
  -h, --help            show this help message and exit
  --skip-ansible-install
                        allows skipping of ansible install
  -c CURRENCY_TYPE, --currency-type CURRENCY_TYPE
                        bitcoin, ethereum, litecoin
  --smtp                if you have the smpt server, port, username, and
                        password you can set up alerting
  -d, --dry-run         dry-run ansible playbook
```
And the setup will commence 