### PR TITLE
Start monit with delay

### DIFF
--- a/roles/monit/vars/main.yml
+++ b/roles/monit/vars/main.yml
@@ -1,5 +1,5 @@
 monitrc_file_content: |
-  set daemon 60
+  set daemon 60 with start delay 120
   set logfile /var/log/monit.log
   set alert {{ alert_email }} only on { nonexist }
 


### PR DESCRIPTION
fixes #19 by adding a 120 second delay before monit starts up and begins monitoring.